### PR TITLE
Fixed broken links to AvyFly repo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -118,6 +118,6 @@ To run linting and code formatting checks before committing your change, you can
 It is recommended to open an issue before starting work on anything.
 This will allow a chance to talk it over with the owners and validate your approach.
 
-.. _pull request: https://github.com/Georacer/parasect/pulls
+.. _pull request: https://github.com/AvyFly/parasect/pulls
 .. github-only
 .. _Code of Conduct: CODE_OF_CONDUCT.rst

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,11 @@ Parasect
 .. |Read the Docs| image:: https://img.shields.io/readthedocs/parasect/latest.svg?label=Read%20the%20Docs
    :target: https://parasect.readthedocs.io/
    :alt: Read the documentation at https://parasect.readthedocs.io/
-.. |Tests| image:: https://github.com/Georacer/parasect/workflows/Tests/badge.svg
-   :target: https://github.com/Georacer/parasect/actions?workflow=Tests
+.. |Tests| image:: https://github.com/AvyFly/parasect/workflows/Tests/badge.svg
+   :target: https://github.com/AvyFly/parasect/actions?workflow=Tests
    :alt: Tests
-.. |Codecov| image:: https://codecov.io/gh/Georacer/parasect/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/Georacer/parasect
+.. |Codecov| image:: https://codecov.io/gh/AvyFly/parasect/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/AvyFly/parasect
    :alt: Codecov
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
@@ -95,7 +95,7 @@ This project was generated from `@cjolowicz`_'s `Hypermodern Python Cookiecutter
 .. _MIT license: https://opensource.org/licenses/MIT
 .. _PyPI: https://pypi.org/
 .. _Hypermodern Python Cookiecutter: https://github.com/cjolowicz/cookiecutter-hypermodern-python
-.. _file an issue: https://github.com/Georacer/parasect/issues
+.. _file an issue: https://github.com/AvyFly/parasect/issues
 .. _pip: https://pip.pypa.io/
 .. github-only
 .. _Contributor Guide: CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,4 +13,4 @@
    contributing
    Code of Conduct <codeofconduct>
    License <license>
-   Changelog <https://github.com/Georacer/parasect/releases>
+   Changelog <https://github.com/AvyFly/parasect/releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,15 @@ description = "Parasect"
 authors = ["George Zogopoulos <geo.zogop.papal@gmail.com>"]
 license = "MIT"
 readme = "README.rst"
-homepage = "https://github.com/Georacer/parasect"
-repository = "https://github.com/Georacer/parasect"
+homepage = "https://github.com/AvyFly/parasect"
+repository = "https://github.com/AvyFly/parasect"
 documentation = "https://parasect.readthedocs.io"
 classifiers = [
     "Development Status :: 4 - Beta",
 ]
 
 [tool.poetry.urls]
-Changelog = "https://github.com/Georacer/parasect/releases"
+Changelog = "https://github.com/AvyFly/parasect/releases"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
They were previously pointing to the non-existing repo Georacer/