### PR TITLE
Bugfix/component parameters

### DIFF
--- a/src/parasect/_helpers.py
+++ b/src/parasect/_helpers.py
@@ -462,7 +462,7 @@ class Parameter:
     reboot_required = False
     group = None
     vid: int  # Vehicle ID, default 1
-    cid: int  # Componenet ID, default 1
+    cid: int  # Component ID, default 1
 
     def __init__(
         self,

--- a/src/parasect/build_lib.py
+++ b/src/parasect/build_lib.py
@@ -515,10 +515,11 @@ class Meal:
         header_model = get_boilerplate(ConfigPaths().staple_dishes, "header")
         yield from self.build_header_footer(header_model, self.header, "px4")
 
-        param_names = sorted(self.param_list.keys())
-        for param_name in param_names:
-            param_value = self.param_list[param_name].get_pretty_value()
-            internal_type = self.param_list[param_name].param_type
+        param_hashes = sorted(self.param_list.keys())
+        for param_hash in param_hashes:
+            param_name = self.param_list[param_hash].name
+            param_value = self.param_list[param_hash].get_pretty_value()
+            internal_type = self.param_list[param_hash].param_type
             if internal_type == "FLOAT":
                 param_type = 9
             elif internal_type == "INT32":
@@ -528,8 +529,8 @@ class Meal:
                     f"Unknown parameter type {internal_type} for parameter {param_name}"
                 )
 
-            vid = self.param_list[param_name].vid
-            cid = self.param_list[param_name].cid
+            vid = self.param_list[param_hash].vid
+            cid = self.param_list[param_hash].cid
             yield f"{vid}\t{cid}\t{param_name}\t{param_value}\t{param_type}\n"
 
     def export_to_px4af(self, version: int) -> Generator[str, None, None]:
@@ -554,9 +555,10 @@ class Meal:
         else:
             indentation = ""
 
-        param_names = sorted(self.param_list.keys())
-        for param_name in param_names:
-            param_value = self.param_list[param_name].get_pretty_value()
+        param_hashes = sorted(self.param_list.keys())
+        for param_hash in param_hashes:
+            param_name = self.param_list[param_hash].name
+            param_value = self.param_list[param_hash].get_pretty_value()
 
             yield f"{indentation}param {directive} {param_name} {param_value}\n"
 
@@ -588,8 +590,9 @@ class Meal:
 
         indentation = ""
 
-        param_names = sorted(self.param_list.keys())
-        for param_name in param_names:
+        param_hashes = sorted(self.param_list.keys())
+        for param_name in param_hashes:
+            param_name = self.param_list[param_name].name
             param_value = self.param_list[param_name].get_pretty_value()
 
             yield f"{indentation}{param_name},{param_value}\n"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -328,6 +328,22 @@ class TestPX4ParamReaders:
             _helpers.read_params_qgc(new_file)
         assert str(exc_info.value) == "Could not extract any parameter from file."
 
+    def test_qgc_cid_shadowing(self, tmp_path):
+        """Verify that the same parameter in a different component doesn't shadow the former."""
+        new_entry = ["1	2	ASPD_SCALE_1	2.0	9"]
+        path = tmp_path
+        new_file = path / "edited.params"
+        old_fp = open(utils.PX4_GAZEBO_PARAMS)
+        old_lines = old_fp.readlines()
+        new_fp = open(new_file, "a")
+        new_fp.writelines(old_lines[0:-1])  # Stop right before the </parameters> tag
+        new_fp.writelines(new_entry)
+        new_fp.close()
+
+        parameter_list = _helpers.read_params(new_file)
+        # Test if the parameter exists, is in the correct group and has the correct type and value
+        assert parameter_list["ASPD_SCALE_1"].value == pytest.approx(1)
+
     def test_ulog_param(self):
         """Test reading from a parameter file extracted from a .ulg via ulog_params."""
         parameter_list = _helpers.read_params(utils.PX4_ULOG_PARAMS_FILE)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -201,13 +201,16 @@ class TestParameterList:
         light_meal = generic_meals["light_meal"]
         new_parameter_list = _helpers.ParameterList(light_meal.param_list)
         assert light_meal.param_list.keys() == new_parameter_list.keys()
+        assert not (light_meal.param_list.params is new_parameter_list.params)
 
     def test_subtract(self, generic_meals):
         """Test the __sub__ operation."""
         spicy_meal = generic_meals["spicy_meal"]
         light_meal = generic_meals["light_meal"]
         params_diff = spicy_meal.param_list - light_meal.param_list
-        assert list(params_diff.keys()) == ["CHILLI", "JALLAPENOS"]
+        assert len(params_diff) == 2
+        assert "CHILLI" in params_diff
+        assert "JALLAPENOS" in params_diff
 
     def test_str(self, generic_meals):
         """Test the __str__ operation."""

--- a/tests/test_meal_menus.py
+++ b/tests/test_meal_menus.py
@@ -24,38 +24,38 @@ class TestGenericMeals:
     def test_snack(self, generic_meals):
         """Test if the snack has correctly generated."""
         snack = generic_meals["snack"]
-        assert "APPLE" in snack.param_list.keys()
+        assert "APPLE" in snack.param_list
 
     def test_breakfast(self, generic_meals):
         """Test if the breakfast has correctly generated."""
         breakfast = generic_meals["breakfast"]
-        assert "MILK" in breakfast.param_list.keys()
+        assert "MILK" in breakfast.param_list
 
     def test_light_meal(self, generic_meals):
         """Test if the light_meal has correctly generated."""
         light_meal = generic_meals["light_meal"]
-        assert "BEEF" in light_meal.param_list.keys()
-        assert "CUCUMBER" in light_meal.param_list.keys()
-        assert "MUSHROOMS" not in light_meal.param_list.keys()
-        assert "VINEGAR" not in light_meal.param_list.keys()
-        assert "EGG" not in light_meal.param_list.keys()
-        assert "SALT" not in light_meal.param_list.keys()
-        assert "GRAVY" not in light_meal.param_list.keys()
+        assert "BEEF" in light_meal.param_list
+        assert "CUCUMBER" in light_meal.param_list
+        assert "MUSHROOMS" not in light_meal.param_list
+        assert "VINEGAR" not in light_meal.param_list
+        assert "EGG" not in light_meal.param_list
+        assert "SALT" not in light_meal.param_list
+        assert "GRAVY" not in light_meal.param_list
 
     def test_spicy_meal(self, generic_meals):
         """Test if the spicy_meal has correctly generated."""
         spicy_meal = generic_meals["spicy_meal"]
-        assert "BEEF" in spicy_meal.param_list.keys()
-        assert "CHILLI" in spicy_meal.param_list.keys()
-        assert "EGG" not in spicy_meal.param_list.keys()
+        assert "BEEF" in spicy_meal.param_list
+        assert "CHILLI" in spicy_meal.param_list
+        assert "EGG" not in spicy_meal.param_list
 
     def test_full_meal(self, generic_meals):
         """Test if the full_meal has correctly generated."""
         full_meal = generic_meals["full_meal"]
-        assert "BEEF" in full_meal.param_list.keys()
-        assert "CHILLI" not in full_meal.param_list.keys()
-        assert "EGG" in full_meal.param_list.keys()
-        assert "PISTACHIO" not in full_meal.param_list.keys()
+        assert "BEEF" in full_meal.param_list
+        assert "CHILLI" not in full_meal.param_list
+        assert "EGG" in full_meal.param_list
+        assert "PISTACHIO" not in full_meal.param_list
 
     def test_christmass_meal(self, generic_meals):
         """Test if the christmass_meal has correctly generated."""
@@ -65,5 +65,5 @@ class TestGenericMeals:
     def test_dangerous_combinations(self, generic_meals):
         """Test if the dangerous_combinations has correctly generated."""
         dangerous_combinations = generic_meals["dangerous_combinations"]
-        assert "MILK" in dangerous_combinations.param_list.keys()
-        assert "COFFEE" in dangerous_combinations.param_list.keys()
+        assert "MILK" in dangerous_combinations.param_list
+        assert "COFFEE" in dangerous_combinations.param_list


### PR DESCRIPTION
Fixed bug with parameter shadowing

A parameter from a second component would shadow the initial parameter
and replace its value. Now this has been fixed.

Also corrected ParameterList copy constructor. It would not copy the
parameter list, only link it.