### PR TITLE
Modified github workflow of release-drafter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,10 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
+        if: "! steps.check-version.outputs.tag"
         uses: release-drafter/release-drafter@v5.24.0
         with:
-          publish: ${{ steps.check-version.outputs.tag != '' }}
+          publish: false
           tag: ${{ steps.check-version.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It would create a new draft in every PR merge, but would also publish it on every new version tag push. Since the dev. workflow is to create a PR to bump the package version, this would always lead to a new draft being created (with bad, stock formatting) and immediately being released, without a chance to edit it.