### PR TITLE
Drop support for Python less than v3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: pipx run ruff check --output-format=github --target-version=py38
+      - run: pipx run ruff check --output-format=github --target-version=py310
 
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}
@@ -22,12 +22,8 @@ jobs:
           - { python: "3.11", os: "ubuntu-latest", session: "safety" }
           - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.8", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.8", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.11", os: "macos-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "typeguard" }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         entry: end-of-file-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: flake8
         name: flake8
         entry: flake8
@@ -40,7 +40,7 @@ repos:
         entry: pyupgrade
         language: system
         types: [python]
-        args: [--py37-plus]
+        args: [--py310-plus]
       - id: reorder-python-imports
         name: Reorder python imports
         entry: reorder-python-imports
@@ -52,7 +52,7 @@ repos:
         entry: trailing-whitespace-fixer
         language: system
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         exclude: tests/assets
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1

--- a/src/parasect/__main__.py
+++ b/src/parasect/__main__.py
@@ -2,7 +2,6 @@
 import cProfile
 from importlib.metadata import version
 from pstats import Stats
-from typing import Optional
 
 import click
 
@@ -61,10 +60,10 @@ def cli(debug: bool) -> None:
 def compare(
     file_1: str,
     file_2: str,
-    input_folder: Optional[str],
+    input_folder: str | None,
     nocal: bool,
     noop: bool,
-    component: Optional[int],
+    component: int | None,
 ) -> None:
     """Compare command."""
     s = compare_helper(file_1, file_2, input_folder, nocal, noop, component)
@@ -109,11 +108,11 @@ def compare(
     help="Specify the default parameters file to apply to all Meals.",
 )
 def build(
-    config: Optional[str],
+    config: str | None,
     format: str,
-    input_folder: Optional[str],
-    default_parameters: Optional[str],
-    output_folder: Optional[str],
+    input_folder: str | None,
+    default_parameters: str | None,
+    output_folder: str | None,
 ) -> None:
     """Build command."""
     build_helper(

--- a/src/parasect/build_lib.py
+++ b/src/parasect/build_lib.py
@@ -1,13 +1,9 @@
 """Module providing the generation of parameter sets."""
 import os
+from collections.abc import Generator
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict
-from typing import Generator
-from typing import Iterable
-from typing import List
 from typing import Optional
-from typing import Tuple
-from typing import Union
 
 from ._helpers import Allergens
 from ._helpers import BoilerplateText
@@ -50,8 +46,8 @@ class Dish:
     def __init__(
         self,
         dish_model: DishModel,
-        model: Optional[str] = None,
-        sn: Optional[str] = None,
+        model: str | None = None,
+        sn: str | None = None,
     ):
         """Class constructor.
 
@@ -80,7 +76,7 @@ class Dish:
         self,
         dish_model: DishModel,
         model: str,
-        sn: Optional[str] = None,
+        sn: str | None = None,
     ) -> None:
         """Read the model and sn information from the param_dict."""
         # Iterate over all selected models
@@ -99,9 +95,7 @@ class Dish:
         else:
             pass
 
-    def get_variant(
-        self, dish_model: DishModel, variant_name: str
-    ) -> Optional[DishModel]:
+    def get_variant(self, dish_model: DishModel, variant_name: str) -> DishModel | None:
         """Extract the variant from a dish."""
         if dish_model.variants:
             try:
@@ -160,7 +154,7 @@ class Dish:
         self.parse_substances(black_list.substances, self.black_params)
 
     def parse_substances(
-        self, substances: Optional[Substances], storage: ParameterList
+        self, substances: Substances | None, storage: ParameterList
     ) -> None:
         """Parse a Substances object into a ParameterList."""
         if substances is not None:
@@ -175,7 +169,7 @@ class Dish:
         """__iter__ dunder method."""
         yield from self.param_list
 
-    def __contains__(self, item: Union[str, Parameter]) -> bool:
+    def __contains__(self, item: str | Parameter) -> bool:
         """Answer if the Dish contains a parameter."""
         return self.param_list.__contains__(item)
 
@@ -187,7 +181,7 @@ class Dish:
 class Calibration(Dish):
     """Parameter class holding calibration parameters."""
 
-    def __init__(self, frame: Optional[str] = None):
+    def __init__(self, frame: str | None = None):
         """Class constructor."""
         param_dict = get_dish(ConfigPaths().staple_dishes, "calibration")
         super().__init__(param_dict, model=frame)
@@ -196,7 +190,7 @@ class Calibration(Dish):
 class Operator(Dish):
     """Parameter class holding operator-defined parameters."""
 
-    def __init__(self, frame: Optional[str] = None):
+    def __init__(self, frame: str | None = None):
         """Class constructor."""
         param_dict = get_dish(ConfigPaths().staple_dishes, "operator")
         super().__init__(param_dict)
@@ -210,9 +204,9 @@ class Meal:
     is_sitl = False
     is_hitl = False
     add_header = False
-    header: Optional[str] = None
+    header: str | None = None
     add_footer = False
-    footer: Optional[str] = None
+    footer: str | None = None
     parent: Optional["Meal"] = None
     add_new = False
     remove_calibration_flag = False
@@ -224,7 +218,7 @@ class Meal:
     def __init__(
         self,
         meals_menu: MealMenuModel,
-        default_params_filepath: Optional[Path],
+        default_params_filepath: Path | None,
         configs_path: Path,
         name: str = "Unknown",
     ):
@@ -279,7 +273,7 @@ class Meal:
         self.decide_on_operator(meal_dict)
 
         # Read configuration specific modules
-        dishes_dict = self.collect_dishes(meal_dict)  # type: Dict[str, Dish]
+        dishes_dict: dict[str, Dish] = self.collect_dishes(meal_dict)
 
         # Compile all custom parameters flat to make sure they don't overwrite each other
         (
@@ -301,7 +295,7 @@ class Meal:
         self,
         meal_dict: MealType,
         all_meals: MealMenuModel,
-        default_params_filepath: Optional[Path],
+        default_params_filepath: Path | None,
         configs_path: Path,
     ) -> None:
         """Check if a parent key is passed and load its presets."""
@@ -335,7 +329,7 @@ class Meal:
         self,
         meal_dict: MealType,
         configs_path: Path,
-        default_params_filepath: Optional[Path],
+        default_params_filepath: Path | None,
     ) -> None:
         """Generate the default parameters list.
 
@@ -392,8 +386,8 @@ class Meal:
             self.remove_operator_flag = False
 
     def collect_parameter_lists(
-        self, modules_dict: Dict[str, Dish]
-    ) -> Tuple[ParameterList, ParameterList, ParameterList]:
+        self, modules_dict: dict[str, Dish]
+    ) -> tuple[ParameterList, ParameterList, ParameterList]:
         """Parse all modules and collect edited, blacklisted and blacklisted groups parameters."""
         edited_param_list = ParameterList()
         black_param_list = ParameterList()
@@ -446,7 +440,7 @@ class Meal:
     def apply_edits(
         self,
         edited_param_list: ParameterList,
-        default_params_filepath: Optional[Path],
+        default_params_filepath: Path | None,
     ) -> None:
         """Edit custom parameters."""
         if not self.add_new:
@@ -468,7 +462,7 @@ class Meal:
                 )
                 self.param_list.add_param(param, safe=False)
 
-    def collect_dishes(self, meal_dict: MealType) -> Dict[str, Dish]:
+    def collect_dishes(self, meal_dict: MealType) -> dict[str, Dish]:
         """Collect all dishes from the configuration dict."""
         dishes_dict = dict()
         for dish_name in meal_dict.keys():
@@ -481,8 +475,8 @@ class Meal:
 
             # Parse the model/serial-number designation
             dish_designation = meal_dict[dish_name]
-            model: Optional[str]
-            sn: Optional[str]
+            model: str | None
+            sn: str | None
             if dish_designation is not None:
                 model_sn = dish_designation.split("/")  # type: ignore # Pydantic guarantees this is a string
                 model = model_sn[0]
@@ -504,7 +498,7 @@ class Meal:
     def build_header_footer(
         self,
         boilerplate_model: BoilerplateText,
-        variant_name: Optional[str],
+        variant_name: str | None,
         format_type: Formats,
     ) -> Generator[str, None, None]:
         """Grab the header and footer sections from the corresponding dish."""
@@ -528,14 +522,14 @@ class Meal:
             variants = boilerplate_model.formats[format_type.value].variants
             if variants is not None:
                 meal_text = variants[variant_name].common
-                for row in meal_text:  # type: ignore # Pydantic guarantees this is a List[str]
+                for row in meal_text:  # type: ignore # Pydantic guarantees this is a list[str]
                     yield row + "\n"
 
     def __str__(self):
         """__str__ dunder method."""
         return self.param_list.__str__()
 
-    def __contains__(self, item: Union[str, Parameter]) -> bool:
+    def __contains__(self, item: str | Parameter) -> bool:
         """Answer if the Meal contains a parameter."""
         return self.param_list.__contains__(item)
 
@@ -704,7 +698,7 @@ class Meal:
             raise ValueError(f"Output format {format} not supported.")
 
 
-def build_meals(names: Optional[List[str]] = None) -> Dict[str, Meal]:
+def build_meals(names: list[str] | None = None) -> dict[str, Meal]:
     """Build the meal of the provided aircraft."""
     meals_menu = get_meals_menu(ConfigPaths().meals)
 
@@ -746,11 +740,11 @@ def build_filename(format: Formats, meal: Meal) -> str:
 
 
 def build_helper(
-    meal_ordered: Optional[str],
+    meal_ordered: str | None,
     format: Formats,
-    input_folder: Optional[str],
-    default_params: Optional[str],
-    output_folder: Optional[str] = None,
+    input_folder: str | None,
+    default_params: str | None,
+    output_folder: str | None = None,
     sitl: bool = False,
 ) -> None:
     """Build parameter sets.
@@ -769,7 +763,7 @@ def build_helper(
     Raises:
         ValueError: If *meal_ordered* is None (hence all the meals will be exported) but no *output_folder* is specified.
     """
-    meal_list: Optional[List[str]]
+    meal_list: list[str] | None
     if meal_ordered is not None:
         meal_list = [meal_ordered]
     else:
@@ -813,7 +807,7 @@ def build_helper(
         export_meal(meal, format, output_folder_path)
 
 
-def convert_str_to_path(path: Optional[str]) -> Optional[Path]:
+def convert_str_to_path(path: str | None) -> Path | None:
     """Convert a str path representation to Optional[Path]."""
     if path:
         return Path(path)
@@ -834,7 +828,7 @@ def make_folder(folder_path: Path) -> None:
             print("Failed to create folder")
 
 
-def export_meal(config: Meal, format: Formats, output_path: Optional[Path]) -> None:
+def export_meal(config: Meal, format: Formats, output_path: Path | None) -> None:
     """Export a configuration to a folder or the screen."""
     if output_path is not None:
         make_folder(output_path)

--- a/src/parasect/compare_lib.py
+++ b/src/parasect/compare_lib.py
@@ -1,12 +1,6 @@
 """Module providing the comparison of parameter sets."""
 import itertools as it
 from pathlib import Path
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import Union
 
 from ._helpers import ConfigPaths
 from ._helpers import filter_regex
@@ -28,8 +22,8 @@ def get_vehicles_comparison(
     param_list_2: ParameterList,
     nocal: bool,
     noop: bool,
-    component: Optional[int] = None,
-) -> List:
+    component: int | None = None,
+) -> list:
     """Top-level comparison function.
 
     Returns a list of comparison results
@@ -68,7 +62,7 @@ def get_vehicles_comparison(
 
 def collect_vid_cid(
     param_list_1: ParameterList, param_list_2: ParameterList
-) -> Dict[int, Set[int]]:
+) -> dict[int, set[int]]:
     """Collect vehicle IDs and component IDs.
 
     Args:
@@ -76,12 +70,12 @@ def collect_vid_cid(
         param_list_2: The second ParameterList to parse for VIDs and CIDs.
 
     Returns:
-        A Dict where the keys are the VIDs found. The value of each key is the
+        A dict where the keys are the VIDs found. The value of each key is the
         CIDs found in every VID.
-        The result will never be an empty Dict because the Parameter object is
+        The result will never be an empty dict because the Parameter object is
         initialized with VID=1 and CID=1.
     """
-    id_dict = dict()  # type: Dict[int, Set[int]]
+    id_dict: dict[int, set[int]] = dict()
     for param in it.chain(param_list_1, param_list_2):
         # If this VID is new, create it
         if param.vid not in id_dict.keys():
@@ -96,9 +90,9 @@ def collect_vid_cid(
 def compare_parameter_lists(
     param_list_1: ParameterList,
     param_list_2: ParameterList,
-    vid: Optional[int],
-    cid: Optional[int],
-) -> List[Tuple[Optional[Parameter], Optional[Parameter]]]:
+    vid: int | None,
+    cid: int | None,
+) -> list[tuple[Parameter | None, Parameter | None]]:
     """Compare two parameter lists, potentially filtering with vid and cid.
 
     Returns a list of tuples. Each tuple contains the old parameter and the new parameter.
@@ -114,8 +108,8 @@ def compare_parameter_lists(
     for param_name in all_param_names:
         param_diff = False
 
-        param_1: Optional[Parameter]
-        param_2: Optional[Parameter]
+        param_1: Parameter | None
+        param_2: Parameter | None
         # Parameter only in first list
         if param_name in param_names_1 and param_name not in param_names_2:
             param_1 = param_list_1[param_name]
@@ -151,10 +145,10 @@ def compare_parameter_lists(
 
 
 def param_id_test(
-    param_1: Optional[Parameter],
-    param_2: Optional[Parameter],
-    vid: Optional[int],
-    cid: Optional[int],
+    param_1: Parameter | None,
+    param_2: Parameter | None,
+    vid: int | None,
+    cid: int | None,
 ) -> bool:
     """Decide if the two parameters should be compared with each other given the demanded vehicle id and component id.
 
@@ -191,7 +185,7 @@ def param_id_test(
         return False
 
 
-def comparison_spec_1(vid: Optional[int], cid: Optional[int]) -> bool:
+def comparison_spec_1(vid: int | None, cid: int | None) -> bool:
     """Decide if two parameters should be compared in the context of the provided vid and cid."""
     if (vid is None) ^ (cid is None):
         raise ValueError("Unhandled input values")
@@ -205,10 +199,10 @@ def comparison_spec_1(vid: Optional[int], cid: Optional[int]) -> bool:
 
 
 def comparison_spec_2(
-    param_1: Optional[Parameter],
-    param_2: Optional[Parameter],
-    vid: Optional[int],
-    cid: Optional[int],
+    param_1: Parameter | None,
+    param_2: Parameter | None,
+    vid: int | None,
+    cid: int | None,
 ) -> bool:
     """If p1 is None, then test only for p2. And vice versa.
 
@@ -234,10 +228,10 @@ def comparison_spec_2(
 
 
 def comparison_spec_3(
-    param_1: Optional[Parameter],
-    param_2: Optional[Parameter],
-    vid: Optional[int],
-    cid: Optional[int],
+    param_1: Parameter | None,
+    param_2: Parameter | None,
+    vid: int | None,
+    cid: int | None,
 ) -> bool:
     """If both parameters' ids match the requested, do compare them.
 
@@ -268,14 +262,14 @@ def comparison_spec_3(
 #     return True
 
 
-def values_differ(v1: Union[int, float], v2: Union[int, float]) -> bool:
+def values_differ(v1: int | float, v2: int | float) -> bool:
     """Compare if two values differ up to the level of precision."""
     return abs(v1 - v2) / (max(abs(v1), abs(v2)) + EPS) > PARAM_EPS_PCT
 
 
 def get_column_lengths(
-    comparison_list: List[Tuple[Optional[Parameter], Optional[Parameter]]]
-) -> List[int]:
+    comparison_list: list[tuple[Parameter | None, Parameter | None]]
+) -> list[int]:
     """Find max param column lengths."""
     max_param_length = 1
     max_value_1_length = 1
@@ -301,8 +295,8 @@ def get_column_lengths(
 
 
 def generate_comparison_strings(
-    comparison_list: List[Tuple[Optional[Parameter], Optional[Parameter]]],
-    column_lengths: List[int],
+    comparison_list: list[tuple[Parameter | None, Parameter | None]],
+    column_lengths: list[int],
 ) -> str:
     """Generate the comparison string output, given a comparison list.
 
@@ -342,8 +336,8 @@ def generate_comparison_strings(
 
 
 def build_comparison_row(
-    param_1: Optional[Parameter],
-    param_2: Optional[Parameter],
+    param_1: Parameter | None,
+    param_2: Parameter | None,
     name_len: int,
     value_1_len: int,
     value_2_len: int,
@@ -379,9 +373,9 @@ def build_comparison_row(
 
 
 def build_comparison_string(
-    comparison_lists: List[List[Tuple[Optional[Parameter], Optional[Parameter]]]],
-    file1: Optional[str],
-    file2: Optional[str],
+    comparison_lists: list[list[tuple[Parameter | None, Parameter | None]]],
+    file1: str | None,
+    file2: str | None,
 ) -> str:
     """Generate the comparison program textual output."""
     # Find column lengths and number of changed parameters
@@ -425,10 +419,10 @@ def build_comparison_string(
 def compare_helper(
     file_1: str,
     file_2: str,
-    input_folder: Optional[str],
+    input_folder: str | None,
     nocal: bool,
     noop: bool,
-    component: Optional[int],
+    component: int | None,
 ) -> str:
     """Compare two parameter files.
 

--- a/tests/test_compare_lib.py
+++ b/tests/test_compare_lib.py
@@ -1,8 +1,4 @@
 """Test cases for the private build_lib module."""
-from typing import List  # noqa: F401 # Older mypy needs this import
-from typing import Optional  # noqa: F401 # Older mypy needs this import
-from typing import Tuple  # noqa: F401 # Older mypy needs this import
-
 import pytest
 
 from . import utils
@@ -139,11 +135,11 @@ class TestGetColumnLegnths:
 
     def test_1(self):
         """Test the case where param_1 == None."""
-        param_list = [
+        param_list: list[tuple[Parameter | None, Parameter | None]] = [
             (None, Parameter("P", 0)),
             (None, Parameter("P1", 10)),
             (None, Parameter("Q", 1)),
-        ]  # type: List[Tuple[Optional[Parameter], Optional[Parameter]]]
+        ]
         c1, c2, c3 = compare_lib.get_column_lengths(param_list)
         assert c1 == 2
         assert c2 == 1
@@ -151,11 +147,11 @@ class TestGetColumnLegnths:
 
     def test_2(self):
         """Test the case where param_1 != None."""
-        param_list = [
+        param_list: list[tuple[Parameter | None, Parameter | None]] = [
             (Parameter("P", 0), None),
             (Parameter("P1", 10), None),
             (Parameter("Q", 1), None),
-        ]  # type: List[Tuple[Optional[Parameter], Optional[Parameter]]]
+        ]
         c1, c2, c3 = compare_lib.get_column_lengths(param_list)
         assert c1 == 2
         assert c2 == 2


### PR DESCRIPTION
> [WARNING] hook id `end-of-file-fixer` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `trailing-whitespace` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.

% `pre-commit migrate-config ` # https://pre-commit.com/#pre-commit-migrate-config
* https://pre-commit.com/#supported-git-hooks

