### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/usage_ardupilot.rst
+++ b/docs/usage_ardupilot.rst
@@ -413,7 +413,7 @@ Unfortunately, *apj_tool* can fit only 8 kilobytes of parameters in the ``.apj``
 
 We have to make a concession and strip our parameter file from the default parameters.
 The downside is that we can no longer use the same parameter file with our GCS to reset all the parameters to the intended value.
-But we can easily circumvent this issue by simply creating a parameter file exclusively for this use, and explicity setting defaults to ``None``.
+But we can easily circumvent this issue by simply creating a parameter file exclusively for this use, and explicitly setting defaults to ``None``.
 
 .. code-block:: yaml
     :caption: meals.yaml

--- a/src/parasect/_helpers.py
+++ b/src/parasect/_helpers.py
@@ -228,7 +228,7 @@ class Substances(RootModel):
     root: List[Tuple[str, Optional[Union[float, int]], Optional[str]]]
 
     def __iter__(self):
-        """Return an interable of the model."""
+        """Return an iterable of the model."""
         return iter(self.root)
 
 

--- a/tests/test_build_lib.py
+++ b/tests/test_build_lib.py
@@ -143,7 +143,7 @@ class TestDishGeneric:
         )
         dish = build_lib.Dish(
             model, "var1"
-        )  # Ask for a varient even if it doesn't exist
+        )  # Ask for a variant even if it doesn't exist
         assert "ING1" in dish
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -43,7 +43,7 @@ class TestLogger:
         assert all(tests)
 
     def test_new_log_file(self):
-        """Test if a new log file is indeed crated at the start of the program."""
+        """Test if a new log file is indeed created at the start of the program."""
         _helpers.Logger().clear()
         log_file = Path("./parasect.log")
         log_file.write_text("old line")
@@ -107,7 +107,7 @@ class TestConfigPathsPX4:
         assert _helpers.ConfigPaths().default_parameters == custom_path
 
     def test_no_parameters(self):
-        """Ensure it is possbile not to have set any default parameters path."""
+        """Ensure it is possible not to have set any default parameters path."""
         del os.environ["PARASECT_DEFAULTS"]
         _helpers.ConfigPaths().DEFAULT_PARAMS_PATH = None
         assert _helpers.ConfigPaths().default_parameters is None
@@ -168,7 +168,7 @@ class TestParameterGeneric:
         assert param.get_pretty_value() == "1"
 
     def test_get_pretty_value_float_float(self):
-        """Verify that float values typed as float have their trailling zeros deleted."""
+        """Verify that float values typed as float have their trailing zeros deleted."""
         param = _helpers.Parameter("TEMP", 1.10)
         param.param_type = "FLOAT32"
         assert param.get_pretty_value() == "1.1"


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=parm,sitl --skip="*.svg,*.xml"`
```
./tests/test_build_lib.py:146: varient ==> variant
./tests/test_helpers.py:46: crated ==> created
./tests/test_helpers.py:110: possbile ==> possible, possibly
./tests/test_helpers.py:171: trailling ==> trailing, trialling, trilling
./docs/usage_ardupilot.rst:416: explicity ==> explicitly
./src/parasect/_helpers.py:231: interable ==> iterable, interactable, integrable, intolerable
```
% `codespell --ignore-words-list=parm,sitl --skip="*.svg,*.xml" --write-changes` 